### PR TITLE
Improve logging

### DIFF
--- a/src/ssm.rs
+++ b/src/ssm.rs
@@ -63,8 +63,8 @@ async fn ssm_get_parameter(
                 "error",
                 true,
                 Some(format!(
-                    "Error calling ssm:GetParameter. Environment variable: {} Path: {} Error: {}",
-                    name, path, error
+                    "Error calling ssm:GetParameter. Environment variable: {} Path: {} Error: {:?}",
+                    name, path, error.into_service_error().meta()
                 )),
             );
         }


### PR DESCRIPTION
String representation of errors in AWS SDK is quite terrible at the moment and `Err.to_string()` only produces `Service error` while hiding all important aspects.

This improvement should display the whole error message

```json
{
    "All": "all",
    "ErrorMessage": "Error calling ssm:GetParameter. Environment variable: TABLE_NAME Path: x-crypteia-ssm:/sdd-pre-payment-notification/table_name Error: Error { code: Some(\"AccessDeniedException\"), message: Some(\"User: arn:aws:sts::123456789:assumed-role/jan-testing-role/jan-testing-session is not authorized to perform: ssm:GetParameter on resource: arn:aws:ssm:eu-central-1:123456789:parameter/testing-service/table_name because no identity-based policy allows the ssm:GetParameter action\"), request_id: Some(\"69cbdd9d-f7e7-406e-bc81-f5f60ac27c1d\"), extras: {} }",
    "_aws": {
        "CloudWatchMetrics": [
            {
                "Dimensions": [
                    [
                        "All",
                        "ssm"
                    ]
                ],
                "Metrics": [
                    {
                        "Name": "error",
                        "Unit": "Count"
                    }
                ],
                "Namespace": "Crypteia"
            }
        ],
        "Timestamp": 1692029912211
    },
    "error": 1,
    "ssm": "ssm"
}

```